### PR TITLE
Fixed bug where copy to clipboard didn't work if navigating from summary

### DIFF
--- a/app/assets/javascripts/jira_push_clipboard.js
+++ b/app/assets/javascripts/jira_push_clipboard.js
@@ -20,7 +20,7 @@ function hideTooltip(btn) {
     }, 1000);
 }
 
-$(document).ready(function() {
+$(document).on('turbolinks:load', function() {
     var clipboard = new Clipboard('#copy-btn', {
         target: function (trigger) {
             prepareClipboardTable();

--- a/app/assets/stylesheets/summary.scss
+++ b/app/assets/stylesheets/summary.scss
@@ -1,3 +1,9 @@
+.summary-container {
+  width: 90%;
+  margin: 0 auto;
+  font-size: 1.5em;
+}
+
 #summary-table {
   font-size: 2em;
 }

--- a/app/assets/stylesheets/table.scss
+++ b/app/assets/stylesheets/table.scss
@@ -12,6 +12,15 @@ $table-border-color: #ddd;
   border: 1px solid $table-border-color;
 }
 
+#jira_issues_clipboard {
+  font-size: 13px;
+  border: 1px solid #ccc;
+
+  a {
+    color: #15c;
+  }
+}
+
 /* dataTable overrides */
 table.dataTable, table.dataTable.no-footer {
   border: 1px solid $table-border-color;

--- a/app/views/jira/status/push/_clipboard_formatting.html.erb
+++ b/app/views/jira/status/push/_clipboard_formatting.html.erb
@@ -1,9 +1,9 @@
 <div style="position:absolute; left:-9999px; top:0px;">
-  <table class="table table-striped" id="jira_issues_clipboard" style="font-size: 13px;">
+  <table class="table table-striped" id="jira_issues_clipboard">
     <thead>
     <tr>
       <th>Key</th>
-      <th>Summary</th>
+      <th style="min-width: 300px">Summary</th>
     </tr>
     </thead>
     <tbody>

--- a/app/views/jira/status/push/summary.html.erb
+++ b/app/views/jira/status/push/summary.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="summary-container">
   <div class="row summary-overview-container">
     <div class="text-center summary-title">
       Deploy Overview


### PR DESCRIPTION
@mikeweaver :

So I ran into a bug today with the clipboard button not working.. I thought it was from my UI updates, but turns out it was a bug if you first view summary page, then click to details -- due to turbolinks. 

I also attempted to increase layout and font size of summary page for the standup TV.. I did not test it on a widescreen TV resolution yet but it will be easy to tweak if the layout is not optimal.